### PR TITLE
Add startup server to enable cPanel deployment

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,6 @@
+const strapi = require('@strapi/strapi');
+
+if (process.env.NODE_ENV == "development")
+    strapi({"autoReload": { "enabled": true }}).start();
+else
+    strapi().start();


### PR DESCRIPTION
To enable cPanel deployment we need a startup script.